### PR TITLE
Added config to owofy

### DIFF
--- a/owo/Config/OwoPluginConfig.cs
+++ b/owo/Config/OwoPluginConfig.cs
@@ -1,0 +1,13 @@
+using Dalamud.Configuration;
+
+namespace owofy.Config
+{
+    public class OwoPluginConfig : IPluginConfiguration
+    {
+        public int Version { get; set; }
+        
+        public bool OwofySystemMessages = true;
+        public bool OwofyPlayerChats = true;
+        public bool OwofyEmotes = true;
+    }
+}

--- a/owo/OwoPlugin.cs
+++ b/owo/OwoPlugin.cs
@@ -1,25 +1,70 @@
 ﻿using System;
-using System.Text;
+using System.Collections.Generic;
+using System.Numerics;
 using System.Text.RegularExpressions;
+using Dalamud.Game.Chat;
 using Dalamud.Game.Chat.SeStringHandling;
 using Dalamud.Game.Chat.SeStringHandling.Payloads;
 using Dalamud.Plugin;
+using ImGuiNET;
+using owofy.Config;
 
 namespace owofy
 {
     public class OwoPlugin : IDalamudPlugin
     {
         private DalamudPluginInterface _pi;
+        
+        private OwoPluginConfig Config;
+        
         private readonly Random _rng = new Random();
+
+        private bool _isMainConfigWindowDrawing;
+        
+        private readonly HashSet<XivChatType> _playerChatTypes = new HashSet<XivChatType>
+        {
+            XivChatType.Alliance, XivChatType.Ls1, XivChatType.Ls2, XivChatType.Ls3, XivChatType.Ls4, XivChatType.Ls5,
+            XivChatType.Ls6, XivChatType.Ls7, XivChatType.Ls8, XivChatType.Party, XivChatType.Say, XivChatType.Shout,
+            XivChatType.Urgent, XivChatType.Yell, XivChatType.CrossParty, XivChatType.FreeCompany,
+            XivChatType.NoviceNetwork, XivChatType.TellIncoming, XivChatType.TellOutgoing, XivChatType.CrossLinkShell1,
+            XivChatType.CrossLinkShell2, XivChatType.CrossLinkShell3, XivChatType.CrossLinkShell4,
+            XivChatType.CrossLinkShell5, XivChatType.CrossLinkShell6, XivChatType.CrossLinkShell7,
+            XivChatType.CrossLinkShell8, XivChatType.PvPTeam
+        };
+        
+        private readonly HashSet<XivChatType> _systemMessageChatTypes = new HashSet<XivChatType>
+        {
+            XivChatType.Debug, XivChatType.Echo, XivChatType.None, XivChatType.Notice, XivChatType.ErrorMessage, 
+            XivChatType.RetainerSale, XivChatType.SystemError, XivChatType.SystemMessage, 
+            XivChatType.GatheringSystemMessage
+        };
+        
+        private readonly HashSet<XivChatType> _emoteChatTypes = new HashSet<XivChatType>
+        {
+            XivChatType.CustomEmote, XivChatType.StandardEmote
+        };
 
         public void Initialize(DalamudPluginInterface pluginInterface)
         {
             _pi = pluginInterface;
+
+            Config = pluginInterface.GetPluginConfig() as OwoPluginConfig ?? new OwoPluginConfig();
+
+            _pi.UiBuilder.OnBuildUi += UiBuilder_OnBuildUi;
+            _pi.UiBuilder.OnOpenConfigUi += (sender, args) => _isMainConfigWindowDrawing = true;
+            
             pluginInterface.Framework.Gui.Chat.OnChatMessage += Chat_OnChatMessage;
         }
 
-        private void Chat_OnChatMessage(Dalamud.Game.Chat.XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
+        private void Chat_OnChatMessage(XivChatType type, uint senderId, ref SeString sender, ref SeString message, ref bool isHandled)
         {
+            if (!Config.OwofyPlayerChats && _playerChatTypes.Contains(type) ||
+                !Config.OwofySystemMessages && _systemMessageChatTypes.Contains(type) ||
+                !Config.OwofyEmotes && _emoteChatTypes.Contains(type))
+            {
+                return;
+            }
+            
             foreach (var payload in message.Payloads)
             {
                 if (payload is TextPayload textPayload)
@@ -43,6 +88,41 @@ namespace owofy
             input = Regex.Replace(input, "!+", " " + RndFace() + " ");
 
             return input;
+        }
+
+        private const string _owofyConfigWelcome = "This window allows you to configure Owofy";
+        private const string _owofySystemMessage = "Owofy non-player chats (system messages, retainer sale, etc)";
+        private const string _owofyPlayerMessage = "Owofy player chats (FC, party, LS, say, etc)";
+
+        private void UiBuilder_OnBuildUi()
+        {
+            if (!_isMainConfigWindowDrawing) return;
+            ImGui.SetNextWindowSize(new Vector2(500, 200));
+
+            if (ImGui.Begin("Owofy Config", ref _isMainConfigWindowDrawing,
+                ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar))
+            {
+                ImGui.Text(_owofyConfigWelcome);
+                ImGui.Separator();
+
+                ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(1, 3));
+                
+                ImGui.Checkbox(Config.OwofySystemMessages ? Owofy(_owofySystemMessage) : _owofySystemMessage,
+                    ref Config.OwofySystemMessages);
+                ImGui.Checkbox(Config.OwofyPlayerChats ? Owofy(_owofyPlayerMessage) : _owofyPlayerMessage,
+                    ref Config.OwofyPlayerChats);
+                ImGui.Checkbox(Config.OwofyEmotes ? "Owofy emeowets" : "Owofy emotes", ref Config.OwofyEmotes);
+                
+                ImGui.PopStyleVar();
+
+                if (ImGui.Button("Save and Close"))
+                {
+                    _isMainConfigWindowDrawing = false;
+                    _pi.SavePluginConfig(Config);
+                }
+                
+                ImGui.End();
+            }
         }
 
         public string Name => "owo plugin";

--- a/owo/owo.csproj
+++ b/owo/owo.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dalamud, Version=5.1.1.0, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="Dalamud, Version=5.2.0.3, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
     </Reference>
     <Reference Include="ImGui.NET, Version=1.72.0.0, Culture=neutral, PublicKeyToken=null">

--- a/owo/owo.csproj
+++ b/owo/owo.csproj
@@ -31,12 +31,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dalamud">
+    <Reference Include="Dalamud, Version=5.1.1.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
-      <Private>False</Private>
     </Reference>
+    <Reference Include="ImGui.NET, Version=1.72.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
+    </Reference>
+    <Reference Include="ImGuiScene, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\AppData\Roaming\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\OwoPluginConfig.cs" />
     <Compile Include="OwoPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/owo/owofy.json
+++ b/owo/owofy.json
@@ -3,7 +3,7 @@
   "Name": "OwO",
   "Description": "This plugin uwu's your chat.",
   "InternalName": "owofy",
-  "AssemblyVersion": "1.1.0.0",
+  "AssemblyVersion": "1.1.0.1",
   "ApplicableVersion": "any",
-  "DalamudApiLevel": 1
+  "DalamudApiLevel": 2
 }


### PR DESCRIPTION
Hi there,

Found it kinda impossible to read through any player interaction with owofy, but every other message becomes so pretty with it!
Added config to be able to choose between different owofiable chat types.

Looks somewhat like this. Config messages are owofied on toggle because why wouldn't those.
![image](https://user-images.githubusercontent.com/37567147/99878009-4f37f480-2c13-11eb-8f18-43037a0a6062.png)

Any suggestions/edits are welcome, of course 🦙 (no alpaca emote saddens me immensely)